### PR TITLE
Fix: VelaProvider for backstage v1.20.0

### DIFF
--- a/src/providers/VelaProvider.ts
+++ b/src/providers/VelaProvider.ts
@@ -38,10 +38,10 @@ export class VelaProvider implements EntityProvider {
             throw new Error('Not initialized');
         }
 
-        const raw = await this.reader.read(
+        const raw = await this.reader.readUrl(
             this.hostname,
         );
-        const data = JSON.parse(raw.toString());
+        const data = await JSON.parse((await raw.buffer()).toString());
 
         /** [5] **/
         const entities: Entity[] = data;


### PR DESCRIPTION
Fixes VelaProvider using reader.readUrl method instead of the deprecated reader.read method on backstage v1.20.0